### PR TITLE
fix: better handle search query list in case some llms respond with extra words

### DIFF
--- a/open_deep_researcher.ipynb
+++ b/open_deep_researcher.ipynb
@@ -1,26 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "authorship_tag": "ABX9TyOe5BsaH0aplNCjknkFtnjg",
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/mshumer/OpenDeepResearcher/blob/main/open_deep_researcher.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -28,11 +12,7 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "!pip install nest_asyncio\n",
-        "import nest_asyncio\n",
-        "nest_asyncio.apply()"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -40,15 +20,19 @@
         "id": "y7cTpP9rDZW-",
         "outputId": "5a443ad2-7a8d-4fef-f315-12108c28f1a2"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Requirement already satisfied: nest_asyncio in /usr/local/lib/python3.11/dist-packages (1.6.0)\n"
           ]
         }
+      ],
+      "source": [
+        "!pip install nest_asyncio\n",
+        "import nest_asyncio\n",
+        "nest_asyncio.apply()"
       ]
     },
     {
@@ -62,6 +46,8 @@
         "import asyncio\n",
         "import aiohttp\n",
         "import json\n",
+        "import re\n",
+        "import ast\n",
         "\n",
         "# =======================\n",
         "# Configuration Constants\n",
@@ -267,14 +253,23 @@
         "        cleaned = response.strip()\n",
         "        if cleaned == \"<done>\":\n",
         "            return \"<done>\"\n",
+        "        # First, try to directly evaluate the cleaned string\n",
         "        try:\n",
-        "            new_queries = eval(cleaned)\n",
+        "            new_queries = ast.literal_eval(cleaned)\n",
         "            if isinstance(new_queries, list):\n",
         "                return new_queries\n",
-        "            else:\n",
-        "                print(\"LLM did not return a list for new search queries. Response:\", response)\n",
-        "                return []\n",
         "        except Exception as e:\n",
+        "            # Direct evaluation failed; try to extract the list part from the string.\n",
+        "            match = re.search(r'(\\[.*\\])', cleaned, re.DOTALL)\n",
+        "            if match:\n",
+        "                list_str = match.group(1)\n",
+        "                try:\n",
+        "                    new_queries = ast.literal_eval(list_str)\n",
+        "                    if isinstance(new_queries, list):\n",
+        "                        return new_queries\n",
+        "                except Exception as e_inner:\n",
+        "                    print(\"Error parsing extracted list:\", e_inner, \"\\nExtracted text:\", list_str)\n",
+        "                    return []\n",
         "            print(\"Error parsing new search queries:\", e, \"\\nResponse:\", response)\n",
         "            return []\n",
         "    return []\n",
@@ -405,12 +400,28 @@
     },
     {
       "cell_type": "code",
-      "source": [],
+      "execution_count": null,
       "metadata": {
         "id": "46Q5XpapDJZT"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": []
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "authorship_tag": "ABX9TyOe5BsaH0aplNCjknkFtnjg",
+      "include_colab_link": true,
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/open_deep_researcher_gradio.ipynb
+++ b/open_deep_researcher_gradio.ipynb
@@ -1,26 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "authorship_tag": "ABX9TyM6XDBP8oqAaLL0GMT0mBj+",
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/mshumer/OpenDeepResearcher/blob/main/open_deep_researcher_gradio.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -43,6 +27,8 @@
         "import aiohttp\n",
         "import gradio as gr\n",
         "import json\n",
+        "import re\n",
+        "import ast\n",
         "\n",
         "# ---------------------------\n",
         "# Configuration Constants\n",
@@ -208,14 +194,23 @@
         "        cleaned = response.strip()\n",
         "        if cleaned == \"<done>\":\n",
         "            return \"<done>\"\n",
+        "        # First, try to directly evaluate the cleaned string\n",
         "        try:\n",
-        "            new_queries = eval(cleaned)\n",
+        "            new_queries = ast.literal_eval(cleaned)\n",
         "            if isinstance(new_queries, list):\n",
         "                return new_queries\n",
-        "            else:\n",
-        "                print(\"LLM did not return a list for new search queries. Response:\", response)\n",
-        "                return []\n",
         "        except Exception as e:\n",
+        "            # Direct evaluation failed; try to extract the list part from the string.\n",
+        "            match = re.search(r'(\\[.*\\])', cleaned, re.DOTALL)\n",
+        "            if match:\n",
+        "                list_str = match.group(1)\n",
+        "                try:\n",
+        "                    new_queries = ast.literal_eval(list_str)\n",
+        "                    if isinstance(new_queries, list):\n",
+        "                        return new_queries\n",
+        "                except Exception as e_inner:\n",
+        "                    print(\"Error parsing extracted list:\", e_inner, \"\\nExtracted text:\", list_str)\n",
+        "                    return []\n",
         "            print(\"Error parsing new search queries:\", e, \"\\nResponse:\", response)\n",
         "            return []\n",
         "    return []\n",
@@ -344,5 +339,21 @@
         "iface.launch()"
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "authorship_tag": "ABX9TyM6XDBP8oqAaLL0GMT0mBj+",
+      "include_colab_link": true,
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
rewrite this part to
```python
   if response:
        cleaned = response.strip()
        if cleaned == "<done>":
            return "<done>"
        # First, try to directly evaluate the cleaned string
        try:
            new_queries = ast.literal_eval(cleaned)
            if isinstance(new_queries, list):
                return new_queries
        except Exception as e:
            # Direct evaluation failed; try to extract the list part from the string.
            match = re.search(r'(\[.*\])', cleaned, re.DOTALL)
            if match:
                list_str = match.group(1)
                try:
                    new_queries = ast.literal_eval(list_str)
                    if isinstance(new_queries, list):
                        return new_queries
                except Exception as e_inner:
                    print("Error parsing extracted list:", e_inner, "\nExtracted text:", list_str)
                    return []
            print("Error parsing new search queries:", e, "\nResponse:", response)
            return []
    return []
```
so that is llms return:
- '<done>': still finish
- only list: still search
- list with explanations: remove explanations then search